### PR TITLE
Switched to StringBuilders

### DIFF
--- a/NightStand.App/NightStand.App.csproj
+++ b/NightStand.App/NightStand.App.csproj
@@ -1,17 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.2</TargetFramework>
-
-    <IsPackable>false</IsPackable>
     <NoWarn>SA1633, SA1652</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.6.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.3.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.3.2" />
+    <PackageReference Include="Bogus" Version="25.0.4" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/NightStand.App/Program.cs
+++ b/NightStand.App/Program.cs
@@ -1,0 +1,51 @@
+﻿namespace NightStand.App
+{
+    using System;
+    using System.Collections.Generic;
+    using Bogus;
+
+    public class Program
+    {
+        public static void Main()
+        {
+            bool exit;
+
+            do
+            {
+                Test();
+
+                Console.WriteLine();
+                Console.WriteLine("Press ENTER to run test again.");
+
+                exit = Console.ReadKey().Key == ConsoleKey.Enter;
+            }
+            while (exit);
+        }
+
+        private static void Test()
+        {
+            var rand = new Random();
+
+            List<Person> samples = new List<Person>();
+
+            Table<Person> table = new Table<Person>
+            {
+                Columns =
+                {
+                    new Column<Person>("Full Name", s => s.FullName),
+                    new Column<Person>("Gender", s => s.Gender.ToString()),
+                    new Column<Person>("Birth Date", s => s.DateOfBirth.ToShortDateString()),
+                    new Column<Person>("City", s => s.Address.City),
+                    new Column<Person>("State", s => s.Address.State),
+                }
+            };
+
+            for (int i = 0; i < 10; i++)
+            {
+                samples.Add(new Person());
+            }
+
+            new ConsoleTableWriter<Person>().Draw(table, samples);
+        }
+    }
+}

--- a/NightStand.sln
+++ b/NightStand.sln
@@ -1,11 +1,13 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.28307.421
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.28606.126
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NightStand", "NightStand\NightStand.csproj", "{C2163AE2-5550-415C-B348-F443CF29F993}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NightStand.Tests", "NightStand.Tests\NightStand.Tests.csproj", "{A26CC66F-2FFD-461D-8FE3-587EC88C0B2D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NightStand.App", "NightStand.App\NightStand.App.csproj", "{6204C761-1D5B-4D03-8A33-708EE96C91AA}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -41,6 +43,18 @@ Global
 		{A26CC66F-2FFD-461D-8FE3-587EC88C0B2D}.Release|x64.Build.0 = Release|Any CPU
 		{A26CC66F-2FFD-461D-8FE3-587EC88C0B2D}.Release|x86.ActiveCfg = Release|Any CPU
 		{A26CC66F-2FFD-461D-8FE3-587EC88C0B2D}.Release|x86.Build.0 = Release|Any CPU
+		{6204C761-1D5B-4D03-8A33-708EE96C91AA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6204C761-1D5B-4D03-8A33-708EE96C91AA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6204C761-1D5B-4D03-8A33-708EE96C91AA}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{6204C761-1D5B-4D03-8A33-708EE96C91AA}.Debug|x64.Build.0 = Debug|Any CPU
+		{6204C761-1D5B-4D03-8A33-708EE96C91AA}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{6204C761-1D5B-4D03-8A33-708EE96C91AA}.Debug|x86.Build.0 = Debug|Any CPU
+		{6204C761-1D5B-4D03-8A33-708EE96C91AA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6204C761-1D5B-4D03-8A33-708EE96C91AA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6204C761-1D5B-4D03-8A33-708EE96C91AA}.Release|x64.ActiveCfg = Release|Any CPU
+		{6204C761-1D5B-4D03-8A33-708EE96C91AA}.Release|x64.Build.0 = Release|Any CPU
+		{6204C761-1D5B-4D03-8A33-708EE96C91AA}.Release|x86.ActiveCfg = Release|Any CPU
+		{6204C761-1D5B-4D03-8A33-708EE96C91AA}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/NightStand/NightStand.csproj
+++ b/NightStand/NightStand.csproj
@@ -10,6 +10,7 @@
     <Copyright>Derek Chasse</Copyright>
     <PackageProjectUrl>https://github.com/DerekChasse/NightStand</PackageProjectUrl>
     <RepositoryUrl>https://github.com/DerekChasse/NightStand</RepositoryUrl>
+    <NoWarn>SA1633, SA1652</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Addressed Issue #9 

Greately improved performance by switching from discreet calls to `TextWriter.Write` to using `StringBuilders`.  By doing this we may not be able to achieve coloring of text.  Users will need to decide if that is an acceptable trade.

Added Sample application for testing and usage examples.